### PR TITLE
Factored out method #open:arguments: from #openShell: on TerminalEmulator

### DIFF
--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -185,19 +185,13 @@ TerminalEmulator class >> open [
 ]
 
 { #category : #'instance creation' }
-TerminalEmulator class >> openBash [
-	^self openShell: '/bin/bash'
-	
-]
-
-{ #category : #'instance creation' }
-TerminalEmulator class >> openShell: path [
+TerminalEmulator class >> open: path arguments: arguments [
 	
 	| win term |
+
 	self checkFont.
 	self cleanUpKeyMap.
-	term := (PTerm new xspawn: { path. '-i'} env: self environ ).
-	"term := (PTermEcho new)."
+	term := PTerm new xspawn: { path } , arguments env: self environ.
 	win := self open.
 	term asProtocolStack
 		push: TerminalEmulatorXterm new;
@@ -206,7 +200,20 @@ TerminalEmulator class >> openShell: path [
 		run.
 	win extent: win extent.
 	^ win	
+
+]
+
+{ #category : #'instance creation' }
+TerminalEmulator class >> openBash [
+	^self openShell: '/bin/bash'
 	
+]
+
+{ #category : #'instance creation' }
+TerminalEmulator class >> openShell: path [
+	
+	^ self open: path arguments: #('-i')
+
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
I factored out a method `#open:arguments:` from `#openShell:` so that other arguments can be passed.

Example which runs Bash as a login shell within one’s home directory:

```
TerminalEmulator open: '/bin/sh' arguments: #('-c' 'cd ~; exec /bin/bash -l')
```