### PR TITLE
Changed #fontsDir and LibPTerm’s #moduleName to use the #localDirectory

### DIFF
--- a/PTerm-Core/LibPTerm.class.st
+++ b/PTerm-Core/LibPTerm.class.st
@@ -72,7 +72,7 @@ LibPTerm class >> compile [
 { #category : #compilation }
 LibPTerm class >> mksource [
 	|file stream|
-	file := ('./' asFileReference absolutePath / 'libpterm.c') asFileReference.
+	file := (FileLocator localDirectory absolutePath / 'libpterm.c') asFileReference.
 	file exists ifTrue:[ file delete ].
 	stream := file writeStream.
 	stream nextPutAll: self source.
@@ -243,7 +243,7 @@ LibPTerm >> master [
 
 { #category : #'accessing platform' }
 LibPTerm >> moduleName [
-	^ (('./' asFileReference absolutePath) / 'libpterm.flib') asFileReference pathString
+	^ (FileLocator localDirectory absolutePath / 'libpterm.flib') asFileReference pathString
 ]
 
 { #category : #lib }

--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -111,7 +111,7 @@ TerminalEmulator class >> fontFamily [
 { #category : #font }
 TerminalEmulator class >> fontsDir [
 	|path|
-	path := Smalltalk vmDirectory asFileReference  / 'Fonts'.
+	path := FileLocator localDirectory / 'Fonts'.
 	path exists ifFalse:[ path createDirectory  ].
 	^path
 ]

--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -111,7 +111,7 @@ TerminalEmulator class >> fontFamily [
 { #category : #font }
 TerminalEmulator class >> fontsDir [
 	|path|
-	path := FileLocator localDirectory / 'Fonts'.
+	path := FileLocator localDirectory absolutePath / 'Fonts'.
 	path exists ifFalse:[ path createDirectory  ].
 	^path
 ]


### PR DESCRIPTION
I had the problem that the `#vmDirectory` and `#workingDirectory` were not writable. I would suggest to use the `#localDirectory` instead for ‘Fonts’ and ‘libpterm.flib’.