### PR TITLE
Changed #close on PTerm to send the process SIGHUP

### DIFF
--- a/PTerm-Core/LibPTerm.class.st
+++ b/PTerm-Core/LibPTerm.class.st
@@ -29,6 +29,12 @@ LibPTerm class >> O_RDWR [
 ]
 
 { #category : #'C-constants' }
+LibPTerm class >> SIGHUP [
+
+	^ 1
+]
+
+{ #category : #'C-constants' }
 LibPTerm class >> SIGKILL [
 	^ 9
 ]

--- a/PTerm-Core/PTerm.class.st
+++ b/PTerm-Core/PTerm.class.st
@@ -4,6 +4,7 @@ Class {
 	#instVars : [
 		'master',
 		'pid',
+		'usedFallback',
 		'announcer',
 		'sub',
 		'active',
@@ -19,12 +20,15 @@ PTerm >> announcer [
 
 { #category : #protocol }
 PTerm >> close [
+
 	self master ifNotNil: [
-		self nextPutAllCr: 'exit'.
-		pid ifNotNil: [ 
-			self lib kill: pid signal: self lib class SIGKILL.
-		].
-	]
+		usedFallback ifFalse: [
+			pid ifNotNil: [ 
+				self lib kill: pid signal: self lib class SIGHUP ]
+		] ifTrue: [
+			self nextPutAllCr: 'exit'.
+			pid ifNotNil: [ 
+				self lib kill: pid signal: self lib class SIGKILL ] ] ]
 ]
 
 { #category : #accessing }
@@ -41,7 +45,8 @@ PTerm >> downcall: data [
 PTerm >> initialize [ 
 	announcer := Announcer new.
 	active := false.
-	wbuff := ExternalAddress allocate: 8
+	wbuff := ExternalAddress allocate: 8.
+	usedFallback := false
 ]
 
 { #category : #protocol }
@@ -226,6 +231,7 @@ PTerm >> xspawn: argv env:envs [
 	[ self waitForOutput  ] forkAt: Processor userSchedulingPriority.
 	"try to use the external lib if not sucess, fallback to the posix_spawn"
 	[pid := self lib ttySpawn: master argv: xarray   envs: earray ] on: Error do:[
+		usedFallback := true.
 		self spawn: (argv first) args: xarray   env: earray 
 	].
 	active:= true.


### PR DESCRIPTION
This changes the signal that is sent when a Terminal window is closed to [SIGHUP](https://en.wikipedia.org/wiki/SIGHUP). The previous implementation is still used when the process was spawned in `PTerm>>#xspawn:env:` through the fallback, because I’m not sure whether using SIGHUP would be appropriate in that case.