### PR TITLE
Made PTerm>>#waitForOutput not send #free to the ExternalAddress in ‘wbuff’ if it’s null

### DIFF
--- a/PTerm-Core/PTerm.class.st
+++ b/PTerm-Core/PTerm.class.st
@@ -211,7 +211,7 @@ PTerm >> waitForOutput [
 	self announcer unsubscribe: sub.
 	master := nil.
 	up note: #endpointClosed with: true.
-	wbuff free.
+	wbuff isNull ifFalse: [ wbuff free; beNull ].
 	Transcript  show: 'Terminal closed'; cr.
 ]
 


### PR DESCRIPTION
This should fix the error _‘PrimitiveFailed: primitive #free in ExternalAddress failed’_ that occurs when reopening a Pharo image which was saved with open Terminal windows.