### PR TITLE
Moved creation of the Process for #waitForOutput in PTerm from #xspawn:env: to #run

### DIFF
--- a/PTerm-Core/PTerm.class.st
+++ b/PTerm-Core/PTerm.class.st
@@ -109,6 +109,7 @@ PTerm >> run [
 	sub := self announcer when: PTermDataEvent  do: [ :e|
 		e data do:[:c|
 			up upcall: c codePoint ]].
+	[ self waitForOutput ] forkAt: Processor userSchedulingPriority
 
 ]
 
@@ -228,7 +229,6 @@ PTerm >> xspawn: argv env:envs [
 	xarray ifNotNil: [ xarray := xarray getHandle ].
 	earray ifNotNil: [ earray := earray getHandle ] ifNil: [Smalltalk os environment environ getHandle].
 	master := self lib master.
-	[ self waitForOutput  ] forkAt: Processor userSchedulingPriority.
 	"try to use the external lib if not sucess, fallback to the posix_spawn"
 	[pid := self lib ttySpawn: master argv: xarray   envs: earray ] on: Error do:[
 		usedFallback := true.


### PR DESCRIPTION
Example:

```
TerminalEmulator open: '/bin/bash' arguments: #('-c' 'for i in {1..10}; do date "+$i: %s"; done; read -n 1')
```

Problem: the output shown in the Terminal window did not always start at line 1.

The fix in commit c4794af5ffb93433 postpones creation of the Process for `#waitForOutput` to avoid announcing a PTermDataEvent before it can be received.