### PR TITLE
Fix keyboard and mouse handling problem in pharo 9

### DIFF
--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -416,8 +416,8 @@ TerminalEmulator >> openOn: ttyMorph [
 	"Figure out what our extent should be based on how much extra space we use for decoration."
 	ext := tty preferredExtent						"the extent that the tty would like to receive"
 		+ self extent - self ttyLayoutBounds extent.	"window decoration"
-	self activeHand keyboardFocus: nil.			"make sure we get focus when we're opened"
-	self extent: ext; openInWorldExtent: ext.
+	self currentWorld activeHand keyboardFocus: nil.			"make sure we get focus when we're opened"
+	self extent: ext; openInWorld.
 	tty install; run
 ]
 

--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -485,12 +485,12 @@ TerminalEmulator >> setWindowTitle: aString [
 TerminalEmulator >> simulateShortcutAsKeyStroke: comb [
 	|evt|
 	evt := KeyboardEvent new 
-				setType: #keystroke 
+				setType: #keyDown 
 				buttons: comb modifier eventCode
 				position: 0@0 
 				keyValue: comb key asciiValue + 1 - $a asciiValue
 				charCode: comb key asciiValue
-				hand: ActiveHand 
+				hand: ActiveWorld activeHand  
 				stamp: 0.
 	tty keyStroke: evt
 ]

--- a/PTerm-UI/TerminalEmulatorMorph.class.st
+++ b/PTerm-UI/TerminalEmulatorMorph.class.st
@@ -1251,6 +1251,7 @@ TerminalEmulatorMorph >> processKeyEvent: evt [
 	"Handle VT100 control key"
 	(evt controlKeyPressed)
 			ifTrue: [
+				(char = 32) ifTrue: [ ^ down downcall: 0 ].
 				(char between: 65 and: 93) ifTrue: [ char := char + 32 ].
 				(char between: 97 and: 125) ifTrue: [ ^ down downcall: char - 96 ]
 			] ifFalse:[

--- a/PTerm-UI/TerminalEmulatorMorph.class.st
+++ b/PTerm-UI/TerminalEmulatorMorph.class.st
@@ -860,7 +860,7 @@ TerminalEmulatorMorph >> initialize: size [
 	color := TerminalEmulator palette background at:8.
 	"self borderStyle: (BorderStyle color: Color red width: 2)."
 	inset := 2.
-	trackingSelection := false.
+	trackingSelection := true.
 	self
 		initializeTeletype: size;
 		initializeContent;
@@ -992,41 +992,17 @@ TerminalEmulatorMorph >> isConnected [
 ]
 
 { #category : #events }
+TerminalEmulatorMorph >> keyDown: evt [
+	(evt commandKeyPressed | evt controlKeyPressed ) ifTrue:[^self processKeyEvent: evt].
+	evt shiftPressed ifTrue: [ ^self].
+	evt keyValue < 32 ifTrue:[
+		self processKeyEvent: evt
+	].
+]
+
+{ #category : #events }
 TerminalEmulatorMorph >> keyStroke: evt [
-	"Receive a character from the keyboard."
-	| char |
-	scrollOnInput ifTrue: [self pageEnd].
-	char := evt keyValue "keyCharacter asciiValue".
-	evt shiftPressed 
-		ifTrue:
-			[char == 1 ifTrue: [^self pageHome].
-			 char == 4 ifTrue: [^self pageEnd].
-			 char == 11 ifTrue: [^self pageUp: rows // 2].
-			 char == 12 ifTrue: [^self pageDown: rows // 2]].
-	"support both CMD + V/C and CTRL + SHIFT + V/C"
-	(keyboardControlsSelection &
-		((evt commandKeyPressed) | ( (evt controlKeyPressed) & (evt shiftPressed) ) ))
-		ifTrue:
-			[evt keyCharacter asLowercase = $c ifTrue: [^self copySelection].
-			 evt keyCharacter asLowercase = $v ifTrue: [^self sendSelection]].
-	"Handle VT100 control key"
-	(evt controlKeyPressed)
-			ifTrue: [
-				(char between: 65 and: 93) ifTrue: [ char := char + 32 ].
-				(char between: 97 and: 125) ifTrue: [ ^ down downcall: char - 96 ]
-			] ifFalse:[
-				char == 1 ifTrue: [^down downcallAll:#[27 91 72] ].
-				char == 4 ifTrue: [^down downcallAll:#[27 91 70]  ].
-				char == 11 ifTrue: [^down downcallAll:#[27 91 53 126] ].
-				char == 12 ifTrue: [^down downcallAll: #[27 91 54 126]]
-			].
-	(metaSendsEscape and: [evt commandKeyPressed ])
-		ifTrue: [down downcall: Character escape asciiValue].
-	"Cursor keys clash with control keys: differentiate by sending 128+cursorKeyCode."
-	(char == 8 & deleteIsDel and: [evt controlKeyPressed not]) ifTrue: [char := 127].
-	(char < 32 and: [evt controlKeyPressed not]) ifTrue: [char := char + 128].
-	down downcall: char.
-	evt wasHandled: true.
+	self processKeyEvent: evt
 ]
 
 { #category : #events }
@@ -1141,8 +1117,7 @@ TerminalEmulatorMorph >> mouseDown: evt [
 { #category : #events }
 TerminalEmulatorMorph >> mouseEnter: evt [
 	"The pointer just entered the window."
-
-	TextCursor beCursor.
+	self currentHand showTemporaryCursor: TextCursor.
 	self showScrollbar.
 	super mouseEnter: evt
 ]
@@ -1150,8 +1125,7 @@ TerminalEmulatorMorph >> mouseEnter: evt [
 { #category : #events }
 TerminalEmulatorMorph >> mouseLeave: evt [
 	"The cursor just left the window."
-
-	Cursor normal show.
+	self currentHand showTemporaryCursor: nil.
 	"self hideScrollbar."
 	super mouseLeave: evt
 ]
@@ -1254,6 +1228,44 @@ TerminalEmulatorMorph >> preferredExtent [
 	w := self borderWidth + s + inset + (cols * pitch) + inset + self borderWidth.
 	h := self borderWidth + inset + (rows * skip) + inset + self borderWidth.
 	^w@h
+]
+
+{ #category : #events }
+TerminalEmulatorMorph >> processKeyEvent: evt [
+	"Receive a character from the keyboard."
+	| char |
+	scrollOnInput ifTrue: [self pageEnd].
+	char := evt keyValue "keyCharacter asciiValue".
+	evt shiftPressed 
+		ifTrue:
+			[char == 1 ifTrue: [^self pageHome].
+			 char == 4 ifTrue: [^self pageEnd].
+			 char == 11 ifTrue: [^self pageUp: rows // 2].
+			 char == 12 ifTrue: [^self pageDown: rows // 2]].
+	"support both CMD + V/C and CTRL + SHIFT + V/C"
+	(keyboardControlsSelection &
+		((evt commandKeyPressed) | ( (evt controlKeyPressed) & (evt shiftPressed) ) ))
+		ifTrue:
+			[evt keyCharacter asLowercase = $c ifTrue: [^self copySelection].
+			 evt keyCharacter asLowercase = $v ifTrue: [^self sendSelection]].
+	"Handle VT100 control key"
+	(evt controlKeyPressed)
+			ifTrue: [
+				(char between: 65 and: 93) ifTrue: [ char := char + 32 ].
+				(char between: 97 and: 125) ifTrue: [ ^ down downcall: char - 96 ]
+			] ifFalse:[
+				char == 1 ifTrue: [^down downcallAll:#[27 91 72] ].
+				char == 4 ifTrue: [^down downcallAll:#[27 91 70]  ].
+				char == 11 ifTrue: [^down downcallAll:#[27 91 53 126] ].
+				char == 12 ifTrue: [^down downcallAll: #[27 91 54 126]]
+			].
+	(metaSendsEscape and: [evt commandKeyPressed ])
+		ifTrue: [down downcall: Character escape asciiValue].
+	"Cursor keys clash with control keys: differentiate by sending 128+cursorKeyCode."
+	(char == 8 & deleteIsDel and: [evt controlKeyPressed not]) ifTrue: [char := 127].
+	(char < 32 and: [evt controlKeyPressed not]) ifTrue: [char := char + 128].
+	down downcall: char.
+	evt wasHandled: true.
 ]
 
 { #category : #private }
@@ -1450,8 +1462,8 @@ TerminalEmulatorMorph >> selectionPositionAt: screenPosition [
 			[self pageDown: (rows // 8 max: 1).
 			 ^(cols + 1) @ (displayStart + rows)].
 	1 to: rows do: [:i
-		| (pos := (self submorphs at: i) selectionColumnAt: screenPosition) isNil
-			ifFalse: [
+		| (pos := (self submorphs at: i) selectionColumnAt: screenPosition)
+			ifNotNil: [
 				^pos @ (displayStart + i)]].
 	^nil
 ]
@@ -1682,24 +1694,23 @@ TerminalEmulatorMorph >> startSelection: screenPosition [
 	self hideCursor; changed.
 	mousePosition = screenPosition
 		ifTrue:
-			[^selectionEnd isNil
-				ifTrue: [self selectWord: screenPosition]
-				ifFalse: [self selectLine: screenPosition]].
-"
-	'mouse position ' , mousePosition printString,
+			[^selectionEnd
+				ifNil:  [self selectWord: screenPosition]
+				ifNotNil: [self selectLine: screenPosition]].
+
+	"'mouse position ' , mousePosition printString,
 	' screen position ', screenPosition printString, 
 	' selectionEnd ', selectionEnd printString, 
-	'  ' displayAt: 10@150.
-"
+	'  ' displayAt: 10@150."
 	mousePosition := screenPosition.
 	selectionEnd := nil.
 
 	start := self selectionPositionAt: screenPosition.
 	self clearSelection.
 	selectionStart := start.
-"
-	'selection begin ', selectionStart printString, '     ' displayAt: 10@10
-"
+
+	"'selection begin ', selectionStart printString, '     ' displayAt: 10@10"
+
 ]
 
 { #category : #private }
@@ -1751,8 +1762,7 @@ TerminalEmulatorMorph >> trackSelection [
 	"The mouse is down during selection tracking.  Update the visual representation of the selected region."
 
 	| pos |
-	(pos := self selectionPositionAt: Sensor cursorPoint) isNil
-		ifFalse:
+	(pos := self selectionPositionAt: Sensor cursorPoint) ifNotNil:
 			[selectionEnd := pos.
 			 self highlightSelection]
 ]
@@ -1760,9 +1770,12 @@ TerminalEmulatorMorph >> trackSelection [
 { #category : #selection }
 TerminalEmulatorMorph >> trackSelection: screenPosition [
 	"The mouse moved during selection tracking.  Update the visual representation of the selected region."
-
 	(trackingSelection or: [(self selectionPositionAt: screenPosition) isNil])
 		ifFalse: [self trackSelection ]
+		ifTrue:[
+			selectionEnd := (self selectionPositionAt: screenPosition).
+			self highlightSelection	
+		].
 	"self
 				startStepping: #trackSelection
 				at: Time millisecondClockValue

--- a/PTerm-UI/TerminalEmulatorMorph.class.st
+++ b/PTerm-UI/TerminalEmulatorMorph.class.st
@@ -1739,6 +1739,13 @@ TerminalEmulatorMorph >> tab [
 	self showCursor
 ]
 
+{ #category : #events }
+TerminalEmulatorMorph >> takesKeyboardFocus [
+
+	^ true
+
+]
+
 { #category : #geometry }
 TerminalEmulatorMorph >> textBounds [
 	"Answer just the bounds of the text -- excluding border, scroll and inset."

--- a/PTerm-UI/TerminalEmulatorMorph.class.st
+++ b/PTerm-UI/TerminalEmulatorMorph.class.st
@@ -993,7 +993,9 @@ TerminalEmulatorMorph >> isConnected [
 
 { #category : #events }
 TerminalEmulatorMorph >> keyDown: evt [
-	(evt commandKeyPressed | evt controlKeyPressed ) ifTrue:[^self processKeyEvent: evt].
+	evt commandKeyPressed ifTrue:[^self processKeyEvent: evt].
+	evt controlKeyPressed ifTrue: [
+		^ (evt keyValue = 0) ifTrue: [ self ] ifFalse: [ self processKeyEvent: evt ] ].
 	evt shiftPressed ifTrue: [ ^self].
 	evt keyValue < 32 ifTrue:[
 		self processKeyEvent: evt

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Require libc compliant with the host pharo VM (32 or 64 bits) to be installed.
 
 ## Install
 
-Install on pharo 7
+Install on pharo 9
 
 ```smalltalk
 Metacello new
-	repository: 'github://lxsang/PTerm';
+	repository: 'github://lxsang/PTerm:pharo9';
 	baseline:'PTerm';
 	load
 ```


### PR DESCRIPTION
This PR addresses the issue #31.

In pharo 9 and up, some keys such as non printable characters or meta/control keys are not handled by #keystroke event. Instead they are catched by #keyDown event. This PR allow PTerm to catch and process both events.

This PR also fixes the problem of displaying text cursor and text selection.

The solution is partially tested