### PR TITLE
Remove PTerm window menu items from windows other than TerminalEmulator

### DIFF
--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -297,7 +297,7 @@ TerminalEmulator class >> useUnifont [
 
 { #category : #'world menu' }
 TerminalEmulator class >> windowMenuOn: aBuilder [
-	<windowMenu>
+	<windowMenuTerminal>
 	"super windowMenuOn: aBuilder."
 	(aBuilder item: #'Change PTerm default font')
 		order: 2.4;
@@ -401,6 +401,12 @@ TerminalEmulator >> keyStroke: evt [
 TerminalEmulator >> keyboardFocusChange: aBoolean [
 	super keyboardFocusChange: aBoolean.
 	self tty keyboardFocusChange: aBoolean 
+]
+
+{ #category : #'menu building' }
+TerminalEmulator >> menuBuilder [
+
+	^ menuBuilder ifNil: [ menuBuilder := PragmaMenuBuilder withAllPragmaKeywords: { 'windowMenuTerminal'. self discoveredMenuPragmaKeyword } model: self ]
 ]
 
 { #category : #'initialize-release' }


### PR DESCRIPTION
The PTerm window menu items also appeared in the window menu of other windows:

![1](https://user-images.githubusercontent.com/1611248/183238322-4f22cf66-2980-4b83-8e5f-8c2d4a70a049.png) ![2](https://user-images.githubusercontent.com/1611248/183238325-4900fc4c-2204-4a5c-b49c-4ac086c7849f.png)

This PR fixes that so that the menu items only appear in the window menu of Terminal windows:

![3](https://user-images.githubusercontent.com/1611248/183238371-111a45d9-3442-4c9d-acc2-bbc09a2ccec5.png) ![4](https://user-images.githubusercontent.com/1611248/183238378-f58992c0-e66d-4dfa-a675-fda553aaac04.png)
