### PR TITLE
Add support for the ‘operating system command’ used in macOS’s Terminal to keep track of the shell’s working directory

### DIFF
--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -342,8 +342,7 @@ TerminalEmulator class >> windowMenuOn: aBuilder [
 
 { #category : #'menus-window' }
 TerminalEmulator >> browseWorkingDirectory [
-
-	FileList openOn: self workingDirectory
+	[FileList openOn: self workingDirectory] on: Error do:[self cwdNotFound ]
 ]
 
 { #category : #connections }
@@ -358,6 +357,12 @@ TerminalEmulator >> collapseOrExpand [
 
 	super collapseOrExpand.
 	self setLabel: (self isCollapsed ifTrue: [iconTitle] ifFalse: [windowTitle])
+]
+
+{ #category : #events }
+TerminalEmulator >> cwdNotFound [
+	self inform:  'Unable to identify or list the current working directory' 
+      
 ]
 
 { #category : #events }
@@ -433,8 +438,7 @@ TerminalEmulator >> initialize [
 
 { #category : #'menus-window' }
 TerminalEmulator >> inspectWorkingDirectory [
-
-	self workingDirectory inspect
+	[self workingDirectory inspect] on: Error do:[self cwdNotFound ]
 ]
 
 { #category : #events }

--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -613,12 +613,15 @@ TerminalEmulator >> updateTheme [
 { #category : #private }
 TerminalEmulator >> workingDirectory [
 
-	| pid lsofCommand output path |
+	| pid lsofCommand output status path |
 
 	workingDirectory ifNotNil: [ ^ workingDirectory ].
 	pid := self tty session endpoint pid.
-	lsofCommand := 'LC_ALL=C lsof -F n0 -a -d cwd -p {1}' format: { pid }.
+	lsofCommand := 'LC_ALL=C lsof -F n0 -a -d cwd -p {1}; printf "\\n%s" $?' format: { pid }.
 	output := OSPlatform current resultOfCommand: lsofCommand.
+	status := (output copyAfterLast: Character lf) asInteger.
+	status = 0 ifFalse: [
+		Error signal: ('Could not determine working directory (lsof status: {1})' format: { status }) ].
 	path := ByteArray streamContents: [ :pathStream |
 		| outputStream |
 		outputStream := output readStream.

--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -15,7 +15,8 @@ Class {
 	#instVars : [
 		'tty',
 		'windowTitle',
-		'iconTitle'
+		'iconTitle',
+		'workingDirectory'
 	],
 	#classVars : [
 		'AutoClose',
@@ -332,6 +333,19 @@ TerminalEmulator class >> windowMenuOn: aBuilder [
 		order: 2.6;
 		action: [ self selectTheme];
 		withSeparatorAfter.
+	(aBuilder item: #'Browse working directory')
+		order: 9;
+		enabled: #hasWorkingDirectory;
+		action: #browseWorkingDirectory.
+	(aBuilder item: #'Inspect working directory')
+		enabled: #hasWorkingDirectory;
+		action: #inspectWorkingDirectory.
+]
+
+{ #category : #'menus-window' }
+TerminalEmulator >> browseWorkingDirectory [
+
+	FileList openOn: workingDirectory
 ]
 
 { #category : #connections }
@@ -404,6 +418,12 @@ TerminalEmulator >> handlesKeyboard: evt [
 	^true
 ]
 
+{ #category : #'menus-window' }
+TerminalEmulator >> hasWorkingDirectory [
+
+	^ workingDirectory notNil
+]
+
 { #category : #'initialize-release' }
 TerminalEmulator >> initialize [
 
@@ -411,6 +431,12 @@ TerminalEmulator >> initialize [
 	self setLabel: (windowTitle := iconTitle := 'Terminal').
 	self attachKeymapCategory: #TerminalEmulator targetting: self.
 	self extent: 10@10.
+]
+
+{ #category : #'menus-window' }
+TerminalEmulator >> inspectWorkingDirectory [
+
+	workingDirectory inspect
 ]
 
 { #category : #events }
@@ -501,6 +527,15 @@ TerminalEmulator >> setWindowTitle: aString [
 
 	windowTitle := aString.
 	self isCollapsed ifFalse: [self setLabel: aString].
+]
+
+{ #category : #accessing }
+TerminalEmulator >> setWorkingDirectory: fileURLString [
+
+	| fileURL |
+
+	fileURL := [ ZnUrl fromString: fileURLString ] on: Error do: [ :error | nil ].
+	workingDirectory := fileURL ifNotNil: [ fileURL asFileReference ].
 ]
 
 { #category : #events }

--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -335,17 +335,15 @@ TerminalEmulator class >> windowMenuOn: aBuilder [
 		withSeparatorAfter.
 	(aBuilder item: #'Browse working directory')
 		order: 9;
-		enabled: #hasWorkingDirectory;
 		action: #browseWorkingDirectory.
 	(aBuilder item: #'Inspect working directory')
-		enabled: #hasWorkingDirectory;
 		action: #inspectWorkingDirectory.
 ]
 
 { #category : #'menus-window' }
 TerminalEmulator >> browseWorkingDirectory [
 
-	FileList openOn: workingDirectory
+	FileList openOn: self workingDirectory
 ]
 
 { #category : #connections }
@@ -436,7 +434,7 @@ TerminalEmulator >> initialize [
 { #category : #'menus-window' }
 TerminalEmulator >> inspectWorkingDirectory [
 
-	workingDirectory inspect
+	self workingDirectory inspect
 ]
 
 { #category : #events }
@@ -449,6 +447,40 @@ TerminalEmulator >> keyStroke: evt [
 TerminalEmulator >> keyboardFocusChange: aBoolean [
 	super keyboardFocusChange: aBoolean.
 	self tty keyboardFocusChange: aBoolean 
+]
+
+{ #category : #private }
+TerminalEmulator >> nextByteFromLsofOutput: outputStream [
+
+	| character |
+	
+	character := outputStream next.
+	character = $\ ifTrue: [
+		character := outputStream next.
+		character = $b ifTrue: [ ^ Character backspace asciiValue ].
+		character = $f ifTrue: [ ^ Character newPage asciiValue ].
+		character = $r ifTrue: [ ^ Character cr asciiValue ].
+		character = $n ifTrue: [ ^ Character lf asciiValue ].
+		character = $t ifTrue: [ ^ Character tab asciiValue ].
+		character = $\ ifTrue: [ ^ $\ asciiValue ].
+		character = $x ifTrue: [
+			| digitValue1 digitValue2 |
+			digitValue1 := outputStream next digitValue.
+			digitValue2 := outputStream next digitValue.
+			^ digitValue1 * 16 + digitValue2 ].
+		Error signal: ('Could not read lsof output due to unrecognized character escape sequence: {1}' format: {
+			(String with: $\ with: character) printString }) ].
+	character = $^ ifTrue: [
+		"Note that lsof's output is ambiguous in this case, see: https://github.com/lsof-org/lsof/issues/130.
+		We interpret a $^ followed by $A through $_ as a control character, and as a plain $^ otherwise."
+		character := outputStream peek.
+		^ (character asciiValue between: $A asciiValue and: $_ asciiValue)
+			ifTrue: [
+				outputStream next.
+				character asciiValue - $@ asciiValue ]
+			ifFalse: [ $^ asciiValue ] ].
+	^ character asciiValue
+
 ]
 
 { #category : #'initialize-release' }
@@ -572,4 +604,22 @@ TerminalEmulator >> updateFont [
 { #category : #events }
 TerminalEmulator >> updateTheme [
 	tty setUpTheme.
+]
+
+{ #category : #private }
+TerminalEmulator >> workingDirectory [
+
+	| pid lsofCommand output path |
+
+	workingDirectory ifNotNil: [ ^ workingDirectory ].
+	pid := self tty session endpoint pid.
+	lsofCommand := 'LC_ALL=C lsof -F n0 -a -d cwd -p {1}' format: { pid }.
+	output := OSPlatform current resultOfCommand: lsofCommand.
+	path := ByteArray streamContents: [ :pathStream |
+		| outputStream |
+		outputStream := output readStream.
+		outputStream skipTo: Character null; skipTo: Character null; next.
+		[ outputStream peek = Character null ] whileFalse: [
+			pathStream nextPut: (self nextByteFromLsofOutput: outputStream) ] ].
+	^ path utf8Decoded asFileReference
 ]

--- a/PTerm-UI/TerminalEmulatorMorph.class.st
+++ b/PTerm-UI/TerminalEmulatorMorph.class.st
@@ -1662,6 +1662,15 @@ TerminalEmulatorMorph >> setWindowTitle: aString [
 				ifFalse: [systemWindow setLabel: aString]]
 ]
 
+{ #category : #'operating modes' }
+TerminalEmulatorMorph >> setWorkingDirectory: fileURLString [
+
+	systemWindow notNil
+		ifTrue:
+			[(systemWindow isKindOf: TerminalEmulator)
+				ifTrue: [systemWindow setWorkingDirectory: fileURLString]]
+]
+
 { #category : #'cursor control' }
 TerminalEmulatorMorph >> showCursor [
 

--- a/PTerm-UI/TerminalEmulatorXterm.class.st
+++ b/PTerm-UI/TerminalEmulatorXterm.class.st
@@ -175,6 +175,7 @@ TerminalEmulatorXterm >> osc: arg [
 	type := arguments first.
 	(type == 0 or: [type == 1]) ifTrue: [window setIconTitle: arguments last].
 	(type == 0 or: [type == 2]) ifTrue: [window setWindowTitle: arguments last].
+	(type == 7) ifTrue: [window setWorkingDirectory: arguments last].
 	"All others are silently ignored"
 ]
 


### PR DESCRIPTION
This PR adds support for the ‘operating system command’ used in macOS’s Terminal to keep track of the shell’s working directory (see: https://github.com/lxsang/PTerm/pull/26#issuecomment-1154191290), and adds window menu items to browse and inspect the FileReference for that directory.

On macOS, one can open TerminalEmulator like this:

```smalltalk
TerminalEmulator open: '/usr/bin/env'
	arguments: {
		'TERM_PROGRAM=Apple_Terminal'.
		'login'. '-pf'. OSEnvironment current at: 'LOGNAME' }
```

Then the window menu items ‘Browse working directory’ and ‘Inspect working directory’ should be enabled:

<img width="478" alt="1" src="https://user-images.githubusercontent.com/1611248/183241924-f865827a-db2a-4bcb-9ecc-27a45aee586d.png">

<img width="580" alt="2" src="https://user-images.githubusercontent.com/1611248/183241937-9dbc2cf8-eb43-4fd9-9b28-82ece6bf4e4d.png">

It’s best to merge PR https://github.com/lxsang/PTerm/pull/37 first, otherwise the window menus for other windows will be broken (because they include the PTerm menu items but the windows don’t understand `#hasWorkingDirectory`).
