### PR TITLE
Fix message #setEmacsColours: not understood when running emacs or nano with TERM set to ‘xterm’

### DIFF
--- a/PTerm-UI/TerminalEmulatorXterm.class.st
+++ b/PTerm-UI/TerminalEmulatorXterm.class.st
@@ -198,7 +198,7 @@ TerminalEmulatorXterm >> saveBuffer [
 	"Save a copy of the current state of the tty."
 
 	savedBuffer := window bufferState.
-	window setEmacsColours: true
+	"window setEmacsColours: true"
 ]
 
 { #category : #private }


### PR DESCRIPTION
This fixes a MessageNotUnderstood that occurs when running `TERM=xterm emacs` or `TERM=xterm nano`.