### PR TITLE
Change #fontsDir in TerminalEmulator to use the #imageRelativeFontFolder of the FreeTypeFontProvider

### DIFF
--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -112,7 +112,7 @@ TerminalEmulator class >> fontFamily [
 { #category : #font }
 TerminalEmulator class >> fontsDir [
 	|path|
-	path := FileLocator localDirectory / 'Fonts'.
+	path := FreeTypeFontProvider current imageRelativeFontFolder.
 	path exists ifFalse:[ path createDirectory  ].
 	^path
 ]


### PR DESCRIPTION
In pull request #22, I changed the `#fontsDir` to a subdirectory of `#localDirectory`.

I think that was a mistake because that directory is not one of the directories used in the method `FreeTypeFontProvider>>#updateFontsFromSystem`. I probably didn’t notice the mistake because I already had the [‘fonts’ files](https://github.com/lxsang/PTerm/tree/c88a8812d102b3342184daf0b56fa652016d0185/fonts) in another directory (`~/Library/Fonts`, see the method `#macOSXFolderDirectories`).

In this pull request, I propose to change the `#fontsDir` to the directory given by `FreeTypeFontProvider current imageRelativeFontFolder`.