### PR TITLE
Change parent in #menuCommandOn: on TerminalEmulator from #MostUsedTools to #SystemTools

### DIFF
--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -159,9 +159,9 @@ TerminalEmulator class >> menuCommandOn: aBuilder [
 	<worldMenu> 
 	
 	(aBuilder item: #'Terminal')
-		order: 0.8; 
+		order: 4; 
 		icon: self icon;  
-		parent: #'MostUsedTools';
+		parent: #'SystemTools';
 		keyText: 'o, c';
 		help: 'Terminal';
 		action: [ self openBash ].


### PR DESCRIPTION
In `TerminalEmulator class>>#menuCommandOn:`, the parent is set to `#MostUsedTools` which in Pharo 9 (and later) no longer exists. This pull request changes it to `#SystemTools` so that the “Terminal” menu item appears in the first group in the “System” menu (which also includes “File Browser”).