### PR TITLE
Changed #close on PTerm to send the process SIGHUP again

### DIFF
--- a/PTerm-Core/PTerm.class.st
+++ b/PTerm-Core/PTerm.class.st
@@ -20,9 +20,9 @@ PTerm >> announcer [
 { #category : #protocol }
 PTerm >> close [
 	self master ifNotNil: [
-			self nextPutAllCr: 'exit'.
-			pid ifNotNil: [ 
-				self lib kill: pid signal: self lib class SIGKILL ] ]
+		pid ifNotNil: [ 
+			self lib kill: pid signal: self lib class SIGHUP ] ]
+
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This pull request changes `PTerm>>#close` to send SIGHUP (as suggested in a [review on pull request #54](https://github.com/lxsang/PTerm/pull/54#pullrequestreview-1611812064)).