### PR TITLE
Minor fixes for issues 36 and 59

### DIFF
--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -147,7 +147,7 @@ TerminalEmulator class >> menuCommandOn: aBuilder [
 		parent: #'SystemTools';
 		keyText: 'o, c';
 		help: 'Terminal';
-		action: [ self openBash ].
+		action: [ self openDefaultShell  ].
 
 ]
 
@@ -168,6 +168,12 @@ TerminalEmulator class >> open: path arguments: arguments [
 { #category : #'instance creation' }
 TerminalEmulator class >> openBash [
 	^self openShell: '/bin/bash'
+	
+]
+
+{ #category : #'instance creation' }
+TerminalEmulator class >> openDefaultShell [
+	^self open: (OSEnvironment current at: 'SHELL' ifAbsent: [ '/bin/sh' ]) arguments: #()
 	
 ]
 

--- a/PTerm-UI/TerminalEmulatorMorph.class.st
+++ b/PTerm-UI/TerminalEmulatorMorph.class.st
@@ -1276,6 +1276,7 @@ TerminalEmulatorMorph >> processKeyEvent: evt [
 	"Handle VT100 control key"
 	(evt controlKeyPressed)
 			ifTrue: [
+				(char = 0) ifTrue:[^self].
 				(char = 32) ifTrue: [ ^ down downcall: 0 ].
 				(char between: 65 and: 93) ifTrue: [ char := char + 32 ].
 				(char between: 97 and: 125) ifTrue: [ ^ down downcall: char - 96 ]


### PR DESCRIPTION
- fix(#59): don't send NULL when only CTRL key is pressed
- fix(#36): add openDefaultShell class method to TerminalEmulator, world menu now  opend a shell based on the value of the SHELL environment variable