### PR TITLE
Make #xspawn:env: on PTerm use ‘libtty’

### DIFF
--- a/PTerm-Core/LibPTerm.class.st
+++ b/PTerm-Core/LibPTerm.class.st
@@ -166,7 +166,7 @@ LibPTerm >> kill: pid signal: sig [
 
 { #category : #'accessing platform' }
 LibPTerm >> macModuleName [ 
-	^ self moduleName
+	^ 'libtty.dylib'
 ]
 
 { #category : #accessing }
@@ -180,11 +180,6 @@ LibPTerm >> master [
 	st ~= 0 ifTrue: [ self closept: fd. ^ self error: 'Error on unlockpt()' ].
 	^fd
 	
-]
-
-{ #category : #'accessing platform' }
-LibPTerm >> moduleName [
-	^ (FileLocator localDirectory absolutePath / 'libpterm.flib') asFileReference pathString
 ]
 
 { #category : #lib }
@@ -252,9 +247,15 @@ LibPTerm >> stringArrayOf: anArray [
 	^ xarray 
 ]
 
+{ #category : #lib }
+LibPTerm >> ttySpawn: fdm path: path argv: argv envs: envp [
+
+	^ self ffiCall: #(int tty_spawn(int fdm, const char* path, void* argv, void* envp))
+]
+
 { #category : #'accessing platform' }
 LibPTerm >> unixModuleName [
-	^ self moduleName
+	^ 'libtty.so'
 ]
 
 { #category : #lib }

--- a/PTerm-Core/PTerm.class.st
+++ b/PTerm-Core/PTerm.class.st
@@ -201,7 +201,9 @@ PTerm >> xspawn: argv env:envs [
 	xarray ifNotNil: [ xarray := xarray getHandle ].
 	earray ifNotNil: [ earray := earray getHandle ] ifNil: [Smalltalk os environment environ getHandle].
 	master := self lib master.
-	self spawn: (argv first) args: xarray   env: earray.
+	[ pid := self lib ttySpawn: master path: argv first argv: xarray envs: earray ]
+		on: Error do: [ :err |
+			self spawn: argv first args: xarray env: earray ].
 	active := true.
 	Transcript show: 'Command run on process: ', pid asString; cr.
 ]


### PR DESCRIPTION
This pull request makes #xspawn:env: on PTerm use the library added to the VM in [pharo-vm pull request #742](https://github.com/pharo-project/pharo-vm/pull/742). The `posix_spawn` implementation is still used when the library is not available. Using the library fixes issue #58.