### PR TITLE
fix(#65): compatibility with Pharo 13

### DIFF
--- a/PTerm-Core/PTerm.class.st
+++ b/PTerm-Core/PTerm.class.st
@@ -101,7 +101,7 @@ PTerm >> pid [
 PTerm >> run [
 	sub := self announcer when: PTermDataEvent  do: [ :e|
 		e data do:[:c|
-			up upcall: c codePoint ]].
+			up upcall: c codePoint ]] for: self.
 	[ self waitForOutput ] forkAt: Processor userSchedulingPriority
 
 ]
@@ -120,7 +120,7 @@ PTerm >> setWinsize: point [
 	buf at: 6 put: 0.
 	buf at: 7 put: 0.
 	buf at: 8 put:0.
-	st := self lib ioct: self master cmd: self lib class TIOCSWINSZ  arg: buf getHandle.
+	st := self lib ioct: master cmd: self lib class TIOCSWINSZ  arg: buf getHandle.
 	st = 0 ifFalse:[^self error: 'Cannot set window size to', point asString ]
 ]
 

--- a/PTerm-UI/TerminalEmulator.class.st
+++ b/PTerm-UI/TerminalEmulator.class.st
@@ -133,7 +133,7 @@ TerminalEmulator class >> initialize [
 			e data class = LogicalFont ifTrue:[i updateFont]
 			ifFalse:[i updateTheme]
 		]
-	].
+	] for: self.
 ]
 
 { #category : #'world menu' }

--- a/PTerm-UI/TerminalEmulatorLineMorph.class.st
+++ b/PTerm-UI/TerminalEmulatorLineMorph.class.st
@@ -4713,7 +4713,7 @@ TerminalEmulatorLineMorph >> initialize [
 	"Initialize the receiver with empty contents."
 
 	self contents: TerminalEmulatorTextState new.
-	self announcer when: TerminalEmulatorConfigChange  do: [ :e| self setUpFont. Transcript show: 'font changed']. 
+	self announcer when: TerminalEmulatorConfigChange  do: [ :e| self setUpFont. Transcript show: 'font changed'] for: self. 
 	"self on: Character null ctrl  do: [ :e| Transcript show: 'stroke';cr ]"
 	"cursorColour := Color red."
 ]

--- a/PTerm-UI/TerminalEmulatorMorph.class.st
+++ b/PTerm-UI/TerminalEmulatorMorph.class.st
@@ -1725,7 +1725,7 @@ TerminalEmulatorMorph >> showScrollbar [
 
 	scroll isNil
 		ifTrue:
-			[scroll := ScrollBar new model: self;
+			[scroll := (Smalltalk globals at: #ScrollBar ifAbsent: [ ScrollBarMorph ]) new model: self;
 			setValueSelector: #scrollbarValue:.
 			 self
 				addMorphBack: scroll;

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Require libc compliant with the host pharo VM (32 or 64 bits) to be installed.
 
 ## Install
 
-Install on pharo 9 or 10
+Install on pharo 9 and up:
 
 ```smalltalk
 Metacello new


### PR DESCRIPTION
- #when:#do: is deprecated in Announcer, use #when:do:for: instead
- ScrollBar is renamed to ScrollBarMorph

This fix should be compatible with Pharo 9 and up