### PR TITLE
Rename #macModuleName and #unixModuleName on LibPTerm to #macLibraryName and #unixLibraryName

### DIFF
--- a/PTerm-Core/LibPTerm.class.st
+++ b/PTerm-Core/LibPTerm.class.st
@@ -165,7 +165,7 @@ LibPTerm >> kill: pid signal: sig [
 ]
 
 { #category : #'accessing platform' }
-LibPTerm >> macModuleName [ 
+LibPTerm >> macLibraryName [ 
 	^ 'libtty.dylib'
 ]
 
@@ -254,7 +254,7 @@ LibPTerm >> ttySpawn: fdm path: path argv: argv envs: envp [
 ]
 
 { #category : #'accessing platform' }
-LibPTerm >> unixModuleName [
+LibPTerm >> unixLibraryName [
 	^ 'libtty.so'
 ]
 


### PR DESCRIPTION
This pull request renames #macModuleName and #unixModuleName on LibPTerm to #macLibraryName and #unixLibraryName as required by [Pharo pull request #16349](https://github.com/pharo-project/pharo/pull/16349).